### PR TITLE
Add gobble-ractive example to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,33 @@ module.exports = gobble( 'src' ).transform( 'browserify', {
 
 During debugging, running "gobble" will display error messages from Browserify (unlike "gobble build dist" which swallows error messages).
 
+
+## Usage with [gobble-ractive](https://github.com/gobblejs/gobble-ractive)
+
+Given this directory structure:
+```
+./gobblefile.js
+./src/component/some-component.html
+./src/js/app.js
+```
+
+Then, the gobblefile.js should include:
+```javascript
+  gobble( 'src' ).map( 'ractive', { type: 'cjs' } ).transform( 'browserify', {
+    entries: './js/app.js', // can be string or array
+    dest: 'bundle.js'
+  }),
+```
+
+And the javascript/app.js can include:
+```javascript
+var SomeComponent = require('../component/some-component');
+
+var thing = new SomeComponent({
+  el: '#id-of-the-div-where-this-component-should-be-displayed'
+});
+```
+
 ## License
 
 MIT. Copyright 2014 Rich Harris


### PR DESCRIPTION
An example of using Gobble, Browserify, and Ractive together.
