### PR TITLE
Update cacheDependency to use the existing object rather than copy it.

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,12 +30,8 @@ function concat ( stream, callback ) {
 	});
 }
 
-function cacheDependency ( cache, originalDep, inputdir ) {
-	var dep = {};
-	Object.keys( originalDep ).forEach( function ( key ) {
-		dep[ key ] = originalDep[ key ];
-	});
-
+function cacheDependency ( cache, dep, inputdir ) {
+  
 	dep.basedir && ( dep.basedir = dep.basedir.replace( inputdir, '@' ) );
 	dep.id = dep.id.replace( inputdir, '@' );
 	dep.file = dep.file.replace( inputdir, '@' );


### PR DESCRIPTION
This should close gobblejs/gobble-browserify#6

Please review this. This will close the issue but it may prevent the caching mechanism from working.
